### PR TITLE
Switched from package_info to package_info_plus

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -6,7 +6,7 @@ import 'package:dio/adapter.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:package_info/package_info.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import 'enums.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   meta: ^1.1.8
   path_provider: ^1.6.14
-  package_info: ^0.4.3
+  package_info_plus: ^0.6.3
   dio: ^3.0.10
   cookie_jar: ^1.0.1
   dio_cookie_manager: ^1.0.0


### PR DESCRIPTION
## Description
As I described in #14 we should use `package_info_plus` instead `package_info`. I didn't test the changes - I just changed it via GitHub UI.

## Related Tickets
Closes #14