### PR TITLE
makes providerAccessTokenExpiry in Session nullable

### DIFF
--- a/lib/src/models/session.dart
+++ b/lib/src/models/session.dart
@@ -15,7 +15,7 @@ class Session implements Model {
     /// Session Provider Access Token.
     final String providerAccessToken;
     /// Date, the Unix timestamp of when the access token expires.
-    final int providerAccessTokenExpiry;
+    final int? providerAccessTokenExpiry;
     /// Session Provider Refresh Token.
     final String providerRefreshToken;
     /// IP in use when the session was created.


### PR DESCRIPTION
When logging in with email, `null` is returned from the server for `providerAccessTokenExpiry`, but the type is currently `int` and not `int?` which is why an exception flies at this point. Therefore I made the type nullable.