### PR TITLE
Temp fix for `flutter_web_auth` polluting console.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,17 @@ dependencies:
     sdk: flutter
   cookie_jar: ^3.0.1
   device_info_plus: ^3.2.2
-  flutter_web_auth: ^0.4.1
+  
   http: ^0.13.4
   package_info_plus: 1.4.2
   path_provider: ^2.0.9
   web_socket_channel: ^2.2.0
+  # flutter_web_auth: ^0.4.1
+  # Temporary fork of flutter_web_auth addressing issue:
+  # https://github.com/flutter/flutter/issues/103561#issuecomment-1126416045
+  flutter_web_auth:
+    git:
+      url: https://github.com/noga-dev/flutter_web_auth.git
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
Dependency `flutter_web_auth` requires patch for flutter 3.0.0 update, error can be ignored but pollutes console.
Fork provides fix until author merges PR.

See: https://github.com/LinusU/flutter_web_auth/pull/118