### PR TITLE
Update packages

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,14 @@ dependencies:
   flutter:
     sdk: flutter
   cookie_jar: ^3.0.1
-  device_info_plus: ^3.2.2
+  device_info_plus: ^4.0.1
   flutter_web_auth: ^0.4.1
   http: ^0.13.4
-  package_info_plus: 1.4.2
-  path_provider: ^2.0.9
+  package_info_plus: ^1.4.3
+  path_provider: ^2.0.11
   web_socket_channel: ^2.2.0
 
 dev_dependencies:
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This PR updates all dependencies to the latest versions and increases the pub.dev score by 10 points.

The version of `package_info_plus` was once locked to `1.3.0`, then [in this PR](https://github.com/appwrite/sdk-for-flutter/commit/ab73474ca1ee5feb4a0a5780d0856b6c91e2ec77) updated, but without adding a caret.
Since the newer version (than the fixed version from a few months ago) came out only 12 days ago, the fixed version was probably not related to `1.4.2`.