### PR TITLE
Fixed the error 'Param \'number\' is not optional.'

### DIFF
--- a/lib/services/account.dart
+++ b/lib/services/account.dart
@@ -522,7 +522,7 @@ class Account extends Service {
 
         final Map<String, dynamic> params = {
             'userId': userId,
-            'phone': phone,
+            'number': phone,
         };
 
         final Map<String, String> headers = {


### PR DESCRIPTION
Was getting the error `""Param \"number\" is not optional."` so went into the source code and found that in the `/account/session/phone` api `phone` is being passed as `key` instead of `number`.  
Fixed it✌️.