### PR TITLE
Refactor Client initialization for improved idiomaticity and readability

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,0 +1,34 @@
+import 'package:appwrite/appwrite.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+
+  Client.instance.initialize(
+    endPoint: 'https://192.168.178.192/v1',
+    projectId: '5f6d7e2e0d0a2',
+    selfSigned: true, // Use in development only
+  );
+
+  runApp(
+    const App(),
+  );
+}
+
+class App extends StatelessWidget {
+  const App({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'AppWrite Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: Scaffold(
+        body: Center(
+          child: Text('Welcome to AppWrite')
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,3 +1,9 @@
 name: appwrite_example
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+    flutter:
+        sdk: flutter
+    appwrite:
+        path: ../

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -14,10 +14,24 @@ abstract class Client {
   String get endPoint => _endPoint;
   String? get endPointRealtime => _endPointRealtime;
 
-  factory Client(
+  factory Client._(
           {String endPoint = 'https://HOSTNAME/v1',
           bool selfSigned = false}) =>
       createClient(endPoint: endPoint, selfSigned: selfSigned);
+
+  static final instance = Client._();
+
+  Client initialize({String endPoint = 'https://HOSTNAME/v1', String? projectId, bool selfSigned = false}) {
+    instance
+      .._setEndpoint(endPoint)
+      .._setSelfSigned(status: selfSigned);
+
+    if (projectId != null) {
+      instance._setProject(projectId);
+    }
+
+    return instance;
+  }
 
   Future webAuth(Uri url, {String? callbackUrlScheme});
 
@@ -30,14 +44,14 @@ abstract class Client {
     Function(UploadProgress)? onProgress,
   });
 
-  Client setSelfSigned({bool status = true});
+  Client _setSelfSigned({bool status = true});
 
-  Client setEndpoint(String endPoint);
+  Client _setEndpoint(String endPoint);
 
   Client setEndPointRealtime(String endPoint);
 
     /// Your project ID
-  Client setProject(value);
+  Client _setProject(String value);
     /// Your secret JSON Web Token
   Client setJWT(value);
   Client setLocale(value);

--- a/lib/src/client_base.dart
+++ b/lib/src/client_base.dart
@@ -2,21 +2,13 @@ import 'response.dart';
 import 'client.dart';
 import 'enums.dart';
 
-abstract class ClientBase implements Client {  
-    /// Your project ID
-  @override
-  ClientBase setProject(value);
-    /// Your secret JSON Web Token
+abstract class ClientBase implements Client {
+  /// Your secret JSON Web Token
   @override
   ClientBase setJWT(value);
+
   @override
   ClientBase setLocale(value);
-
-  @override
-  ClientBase setSelfSigned({bool status = true});
-
-  @override
-  ClientBase setEndpoint(String endPoint);
 
   @override
   Client setEndPointRealtime(String endPoint);

--- a/lib/src/client_browser.dart
+++ b/lib/src/client_browser.dart
@@ -16,7 +16,7 @@ ClientBase createClient({
   required String endPoint,
   required bool selfSigned,
 }) =>
-    ClientBrowser(endPoint: endPoint, selfSigned: selfSigned);
+    ClientBrowser.instance.initialize(endPoint: endPoint, selfSigned: selfSigned);
 
 class ClientBrowser extends ClientBase with ClientMixin {
   static const int CHUNK_SIZE = 5*1024*1024;
@@ -30,9 +30,8 @@ class ClientBrowser extends ClientBase with ClientMixin {
   @override
   String? get endPointRealtime => _endPointRealtime;
 
-  ClientBrowser({
+  ClientBrowser._({
     String endPoint = 'https://HOSTNAME/v1',
-    bool selfSigned = false,
   }) : _endPoint = endPoint {
     _httpClient = BrowserClient();
     _endPointRealtime = endPoint
@@ -54,12 +53,20 @@ class ClientBrowser extends ClientBase with ClientMixin {
     init();
   }
 
+  static final instance = ClientBrowser._();
+
+  ClientBrowser initialize({String endPoint = 'https://HOSTNAME/v1', String? projectId, bool selfSigned = false}) {
+    return instance
+      .._setEndpoint(endPoint)
+      .._setProject(projectId ?? '')
+      .._setSelfSigned(status: selfSigned);
+  }
+
   @override
   String get endPoint => _endPoint;
 
-     /// Your project ID
-    @override
-    ClientBrowser setProject(value) {
+
+    ClientBrowser _setProject(value) {
         config['project'] = value;
         addHeader('X-Appwrite-Project', value);
         return this;
@@ -78,13 +85,11 @@ class ClientBrowser extends ClientBase with ClientMixin {
         return this;
     }
 
-  @override
-  ClientBrowser setSelfSigned({bool status = true}) {
+  ClientBrowser _setSelfSigned({bool status = true}) {
     return this;
   }
 
-  @override
-  ClientBrowser setEndpoint(String endPoint) {
+  ClientBrowser _setEndpoint(String endPoint) {
     _endPoint = endPoint;
     _endPointRealtime = endPoint
         .replaceFirst('https://', 'wss://')


### PR DESCRIPTION
This PR refactors the initialization of the `Client` class to make it more idiomatic and Dart-like. 

The new initialization method uses named arguments and the initialize function of a singleton instance of `Client`, rather than chaining function calls on a new instance of Client. 

This change should make the code more readable and easier to understand for developers familiar with Dart and Firebase

## What does this PR do?

Before:

```Dart
Client client = Client();
client
    .setEndpoint('https://localhost/v1') // Your Appwrite Endpoint
    .setProject('5e8cf4f46b5e8') // Your project ID
    .setSelfSigned(); // Use only on dev mode with a self-signed SSL cert
```

After:

```Dart
Client.instance.initialize(
   endpoint: 'https://localhost/v1',
   propjectId:'5e8cf4f46b5e8',
   selfSigned: true,
);
```

## Related PRs and Issues

This PR is related to [this issue](https://github.com/appwrite/sdk-for-flutter/issues/94).

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.