### PR TITLE
Additional name to Account

### DIFF
--- a/lib/services/account.dart
+++ b/lib/services/account.dart
@@ -1,5 +1,8 @@
 part of appwrite;
 
+// access Account without conflicting namespaces
+typedef AccountService = Account;
+
     /// The Account service allows you to authenticate and manage a user account.
 class Account extends Service {
     Account(super.client);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR solves the main issue developers face while using the `Account` class with two different behavior. which makes quite long time refactoring due autoimports and large misunderstandings on Unambiguous naming.

Before:

``` dart
import 'package:appwrite/models.dart' as model; // use model prefix to access
import 'package:appwrite/appwrite.dart';

// Account model class - prefix with model to use
model.Account account = model.Account(...);

// Account service class - No prefix
Account accountService = Account(client);  // accout service

```

After:

``` dart
import 'package:appwrite/models.dart'; // no prefix required
import 'package:appwrite/appwrite.dart';

// Account Model - No Prefix required
Account account = Account();

// use AccountService instead of Account
AccountService accountService = AccountService(client); 
```

here we are using just a Type Definition to access the Account with a new name. so it won't show conflicts in imports.
and also this PR is not changing any previously written code. 

## Related PRs and Issues

Related issue: #93 
There are two accounts: models.Account and appwrite.Account

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

- [x] Yes