### PR TITLE
Add proper Linux support in Web Auth

### DIFF
--- a/lib/src/client_io.dart
+++ b/lib/src/client_io.dart
@@ -312,11 +312,13 @@ class ClientIO extends ClientBase with ClientMixin {
     return res;
   }
 
+  bool get _customSchemeAllowed => Platform.isWindows || Platform.isLinux;
+
   @override
   Future webAuth(Uri url, {String? callbackUrlScheme}) {
     return FlutterWebAuth2.authenticate(
       url: url.toString(),
-      callbackUrlScheme: callbackUrlScheme != null && Platform.isWindows ? callbackUrlScheme : "appwrite-callback-" + config['project']!,
+      callbackUrlScheme: callbackUrlScheme != null && _customSchemeAllowed ? callbackUrlScheme : "appwrite-callback-" + config['project']!,
     ).then((value) async {
       Uri url = Uri.parse(value);
       final key = url.queryParameters['key'];


### PR DESCRIPTION
## What does this PR do?

This PR enables proper Linux support using `flutter_web_auth_2` which now supports Linux thanks to the work done in https://github.com/ThexXTURBOXx/flutter_web_auth_2/pull/31

## Test Plan

No test needed as this adds a single check that enables custom URL schemes being allowed on Linux (needed due to the currently implemented workaround approach)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes