### PR TITLE
fixed ExecutionMethod enum naming

### DIFF
--- a/docs/examples/functions/create-execution.md
+++ b/docs/examples/functions/create-execution.md
@@ -11,6 +11,6 @@ Execution result = await functions.createExecution(
     body: '<BODY>', // optional
     xasync: false, // optional
     path: '<PATH>', // optional
-    method: ExecutionMethod.gET, // optional
+    method: ExecutionMethod.get, // optional
     headers: {}, // optional
 );

--- a/lib/src/enums/execution_method.dart
+++ b/lib/src/enums/execution_method.dart
@@ -1,18 +1,16 @@
 part of appwrite.enums;
 
 enum ExecutionMethod {
-    gET(value: 'GET'),
-    pOST(value: 'POST'),
-    pUT(value: 'PUT'),
-    pATCH(value: 'PATCH'),
-    dELETE(value: 'DELETE'),
-    oPTIONS(value: 'OPTIONS');
+  get(value: 'GET'),
+  post(value: 'POST'),
+  put(value: 'PUT'),
+  patch(value: 'PATCH'),
+  delete(value: 'DELETE'),
+  options(value: 'OPTIONS');
 
-    const ExecutionMethod({
-        required this.value
-    });
+  const ExecutionMethod({required this.value});
 
-    final String value;
+  final String value;
 
-    String toJson() => value;
+  String toJson() => value;
 }


### PR DESCRIPTION
## What does this PR do?

For some reason only the ExecutionMethod enum has strange naming, so this PR fixes the naming for this enum to have the same naming concept as others.

## Test Plan

Manual with functions

## Related PRs and Issues
Not related

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes