### PR TITLE
fix: upgrade dependencies (flutter_web_auth_2 version is outdated in Flutter 3.29)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,17 +19,17 @@ dependencies:
   flutter:
     sdk: flutter
   cookie_jar: ^4.0.8
-  device_info_plus: ^10.1.2
-  flutter_web_auth_2: ^3.1.2
+  device_info_plus: ^11.3.3
+  flutter_web_auth_2: ^4.1.0
   http: '>=0.13.6 <2.0.0'
-  package_info_plus: ^8.0.2
-  path_provider: ^2.1.4
-  web_socket_channel: ^3.0.1
-  web: ^1.0.0
+  package_info_plus: ^8.3.0
+  path_provider: ^2.1.5
+  web_socket_channel: ^3.0.2
+  web: ^1.1.1
 
 dev_dependencies:
   path_provider_platform_interface: ^2.1.2
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
-  mockito: ^5.4.4
+  mockito: ^5.4.5


### PR DESCRIPTION
## What does this PR do?

Fixing deprecated dependency "flutter_web_auth_2" and updating other ones.

## Test Plan

I have build my project with AppWrite client SDK successfully.

## Related PRs and Issues

[Issue #238](https://github.com/appwrite/sdk-for-flutter/issues/238)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.