### PR TITLE
remove unnecessary code when setting apiPath variable in service meth…

### DIFF
--- a/lib/services/account.dart
+++ b/lib/services/account.dart
@@ -108,10 +108,7 @@ class Account extends Service {
 
   /// Delete an identity by its unique ID.
   Future deleteIdentity({required String identityId}) async {
-    final String apiPath = '/account/identities/{identityId}'.replaceAll(
-      '{identityId}',
-      identityId,
-    );
+    final String apiPath = '/account/identities/$identityId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -193,10 +190,7 @@ class Account extends Service {
   Future<models.MfaType> createMfaAuthenticator({
     required enums.AuthenticatorType type,
   }) async {
-    final String apiPath = '/account/mfa/authenticators/{type}'.replaceAll(
-      '{type}',
-      type.value,
-    );
+    final String apiPath = '/account/mfa/authenticators/${type.value}';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -219,10 +213,7 @@ class Account extends Service {
     required enums.AuthenticatorType type,
     required String otp,
   }) async {
-    final String apiPath = '/account/mfa/authenticators/{type}'.replaceAll(
-      '{type}',
-      type.value,
-    );
+    final String apiPath = '/account/mfa/authenticators/${type.value}';
 
     final Map<String, dynamic> apiParams = {'otp': otp};
 
@@ -240,10 +231,7 @@ class Account extends Service {
 
   /// Delete an authenticator for a user by ID.
   Future deleteMfaAuthenticator({required enums.AuthenticatorType type}) async {
-    final String apiPath = '/account/mfa/authenticators/{type}'.replaceAll(
-      '{type}',
-      type.value,
-    );
+    final String apiPath = '/account/mfa/authenticators/${type.value}';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -700,10 +688,7 @@ class Account extends Service {
     String? failure,
     List<String>? scopes,
   }) async {
-    final String apiPath = '/account/sessions/oauth2/{provider}'.replaceAll(
-      '{provider}',
-      provider.value,
-    );
+    final String apiPath = '/account/sessions/oauth2/${provider.value}';
 
     final Map<String, dynamic> params = {
       'success': success,
@@ -788,10 +773,7 @@ class Account extends Service {
   /// Use this endpoint to get a logged in user's session using a Session ID.
   /// Inputting 'current' will return the current session being used.
   Future<models.Session> getSession({required String sessionId}) async {
-    final String apiPath = '/account/sessions/{sessionId}'.replaceAll(
-      '{sessionId}',
-      sessionId,
-    );
+    final String apiPath = '/account/sessions/$sessionId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -811,10 +793,7 @@ class Account extends Service {
   /// useful when session expiry is short. If the session was created using an
   /// OAuth provider, this endpoint refreshes the access token from the provider.
   Future<models.Session> updateSession({required String sessionId}) async {
-    final String apiPath = '/account/sessions/{sessionId}'.replaceAll(
-      '{sessionId}',
-      sessionId,
-    );
+    final String apiPath = '/account/sessions/$sessionId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -836,10 +815,7 @@ class Account extends Service {
   /// Sessions](https://appwrite.io/docs/references/cloud/client-web/account#deleteSessions)
   /// instead.
   Future deleteSession({required String sessionId}) async {
-    final String apiPath = '/account/sessions/{sessionId}'.replaceAll(
-      '{sessionId}',
-      sessionId,
-    );
+    final String apiPath = '/account/sessions/$sessionId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -914,10 +890,7 @@ class Account extends Service {
     required String targetId,
     required String identifier,
   }) async {
-    final String apiPath = '/account/targets/{targetId}/push'.replaceAll(
-      '{targetId}',
-      targetId,
-    );
+    final String apiPath = '/account/targets/$targetId/push';
 
     final Map<String, dynamic> apiParams = {'identifier': identifier};
 
@@ -937,10 +910,7 @@ class Account extends Service {
   /// deletion, the device will no longer receive push notifications. The target
   /// must exist and belong to the current user.
   Future deletePushTarget({required String targetId}) async {
-    final String apiPath = '/account/targets/{targetId}/push'.replaceAll(
-      '{targetId}',
-      targetId,
-    );
+    final String apiPath = '/account/targets/$targetId/push';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -1052,10 +1022,7 @@ class Account extends Service {
     String? failure,
     List<String>? scopes,
   }) async {
-    final String apiPath = '/account/tokens/oauth2/{provider}'.replaceAll(
-      '{provider}',
-      provider.value,
-    );
+    final String apiPath = '/account/tokens/oauth2/${provider.value}';
 
     final Map<String, dynamic> params = {
       'success': success,

--- a/lib/services/avatars.dart
+++ b/lib/services/avatars.dart
@@ -22,10 +22,7 @@ class Avatars extends Service {
     int? height,
     int? quality,
   }) async {
-    final String apiPath = '/avatars/browsers/{code}'.replaceAll(
-      '{code}',
-      code.value,
-    );
+    final String apiPath = '/avatars/browsers/${code.value}';
 
     final Map<String, dynamic> params = {
       'width': width,
@@ -59,10 +56,7 @@ class Avatars extends Service {
     int? height,
     int? quality,
   }) async {
-    final String apiPath = '/avatars/credit-cards/{code}'.replaceAll(
-      '{code}',
-      code.value,
-    );
+    final String apiPath = '/avatars/credit-cards/${code.value}';
 
     final Map<String, dynamic> params = {
       'width': width,
@@ -119,10 +113,7 @@ class Avatars extends Service {
     int? height,
     int? quality,
   }) async {
-    final String apiPath = '/avatars/flags/{code}'.replaceAll(
-      '{code}',
-      code.value,
-    );
+    final String apiPath = '/avatars/flags/${code.value}';
 
     final Map<String, dynamic> params = {
       'width': width,

--- a/lib/services/databases.dart
+++ b/lib/services/databases.dart
@@ -14,9 +14,7 @@ class Databases extends Service {
     List<String>? queries,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId);
+        '/databases/$databaseId/collections/$collectionId/documents';
 
     final Map<String, dynamic> apiParams = {'queries': queries};
 
@@ -44,9 +42,7 @@ class Databases extends Service {
     List<String>? permissions,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId);
+        '/databases/$databaseId/collections/$collectionId/documents';
 
     final Map<String, dynamic> apiParams = {
       'documentId': documentId,
@@ -75,10 +71,7 @@ class Databases extends Service {
     List<String>? queries,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents/{documentId}'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId)
-            .replaceAll('{documentId}', documentId);
+        '/databases/$databaseId/collections/$collectionId/documents/$documentId';
 
     final Map<String, dynamic> apiParams = {'queries': queries};
 
@@ -110,10 +103,7 @@ class Databases extends Service {
     List<String>? permissions,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents/{documentId}'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId)
-            .replaceAll('{documentId}', documentId);
+        '/databases/$databaseId/collections/$collectionId/documents/$documentId';
 
     final Map<String, dynamic> apiParams = {
       'data': data,
@@ -142,10 +132,7 @@ class Databases extends Service {
     List<String>? permissions,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents/{documentId}'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId)
-            .replaceAll('{documentId}', documentId);
+        '/databases/$databaseId/collections/$collectionId/documents/$documentId';
 
     final Map<String, dynamic> apiParams = {
       'data': data,
@@ -171,10 +158,7 @@ class Databases extends Service {
     required String documentId,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents/{documentId}'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId)
-            .replaceAll('{documentId}', documentId);
+        '/databases/$databaseId/collections/$collectionId/documents/$documentId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -200,11 +184,7 @@ class Databases extends Service {
     double? min,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents/{documentId}/{attribute}/decrement'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId)
-            .replaceAll('{documentId}', documentId)
-            .replaceAll('{attribute}', attribute);
+        '/databases/$databaseId/collections/$collectionId/documents/$documentId/$attribute/decrement';
 
     final Map<String, dynamic> apiParams = {'value': value, 'min': min};
 
@@ -230,11 +210,7 @@ class Databases extends Service {
     double? max,
   }) async {
     final String apiPath =
-        '/databases/{databaseId}/collections/{collectionId}/documents/{documentId}/{attribute}/increment'
-            .replaceAll('{databaseId}', databaseId)
-            .replaceAll('{collectionId}', collectionId)
-            .replaceAll('{documentId}', documentId)
-            .replaceAll('{attribute}', attribute);
+        '/databases/$databaseId/collections/$collectionId/documents/$documentId/$attribute/increment';
 
     final Map<String, dynamic> apiParams = {'value': value, 'max': max};
 

--- a/lib/services/functions.dart
+++ b/lib/services/functions.dart
@@ -12,10 +12,7 @@ class Functions extends Service {
     required String functionId,
     List<String>? queries,
   }) async {
-    final String apiPath = '/functions/{functionId}/executions'.replaceAll(
-      '{functionId}',
-      functionId,
-    );
+    final String apiPath = '/functions/$functionId/executions';
 
     final Map<String, dynamic> apiParams = {'queries': queries};
 
@@ -44,10 +41,7 @@ class Functions extends Service {
     Map? headers,
     String? scheduledAt,
   }) async {
-    final String apiPath = '/functions/{functionId}/executions'.replaceAll(
-      '{functionId}',
-      functionId,
-    );
+    final String apiPath = '/functions/$functionId/executions';
 
     final Map<String, dynamic> apiParams = {
       'body': body,
@@ -75,9 +69,7 @@ class Functions extends Service {
     required String functionId,
     required String executionId,
   }) async {
-    final String apiPath = '/functions/{functionId}/executions/{executionId}'
-        .replaceAll('{functionId}', functionId)
-        .replaceAll('{executionId}', executionId);
+    final String apiPath = '/functions/$functionId/executions/$executionId';
 
     final Map<String, dynamic> apiParams = {};
 

--- a/lib/services/messaging.dart
+++ b/lib/services/messaging.dart
@@ -12,10 +12,7 @@ class Messaging extends Service {
     required String subscriberId,
     required String targetId,
   }) async {
-    final String apiPath = '/messaging/topics/{topicId}/subscribers'.replaceAll(
-      '{topicId}',
-      topicId,
-    );
+    final String apiPath = '/messaging/topics/$topicId/subscribers';
 
     final Map<String, dynamic> apiParams = {
       'subscriberId': subscriberId,
@@ -40,9 +37,7 @@ class Messaging extends Service {
     required String subscriberId,
   }) async {
     final String apiPath =
-        '/messaging/topics/{topicId}/subscribers/{subscriberId}'
-            .replaceAll('{topicId}', topicId)
-            .replaceAll('{subscriberId}', subscriberId);
+        '/messaging/topics/$topicId/subscribers/$subscriberId';
 
     final Map<String, dynamic> apiParams = {};
 

--- a/lib/services/storage.dart
+++ b/lib/services/storage.dart
@@ -12,10 +12,7 @@ class Storage extends Service {
     List<String>? queries,
     String? search,
   }) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files'.replaceAll(
-      '{bucketId}',
-      bucketId,
-    );
+    final String apiPath = '/storage/buckets/$bucketId/files';
 
     final Map<String, dynamic> apiParams = {
       'queries': queries,
@@ -59,10 +56,7 @@ class Storage extends Service {
     List<String>? permissions,
     Function(UploadProgress)? onProgress,
   }) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files'.replaceAll(
-      '{bucketId}',
-      bucketId,
-    );
+    final String apiPath = '/storage/buckets/$bucketId/files';
 
     final Map<String, dynamic> apiParams = {
       'fileId': fileId,
@@ -95,9 +89,7 @@ class Storage extends Service {
     required String bucketId,
     required String fileId,
   }) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files/{fileId}'
-        .replaceAll('{bucketId}', bucketId)
-        .replaceAll('{fileId}', fileId);
+    final String apiPath = '/storage/buckets/$bucketId/files/$fileId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -121,9 +113,7 @@ class Storage extends Service {
     String? name,
     List<String>? permissions,
   }) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files/{fileId}'
-        .replaceAll('{bucketId}', bucketId)
-        .replaceAll('{fileId}', fileId);
+    final String apiPath = '/storage/buckets/$bucketId/files/$fileId';
 
     final Map<String, dynamic> apiParams = {
       'name': name,
@@ -145,9 +135,7 @@ class Storage extends Service {
   /// Delete a file by its unique ID. Only users with write permissions have
   /// access to delete this resource.
   Future deleteFile({required String bucketId, required String fileId}) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files/{fileId}'
-        .replaceAll('{bucketId}', bucketId)
-        .replaceAll('{fileId}', fileId);
+    final String apiPath = '/storage/buckets/$bucketId/files/$fileId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -171,9 +159,7 @@ class Storage extends Service {
     required String fileId,
     String? token,
   }) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files/{fileId}/download'
-        .replaceAll('{bucketId}', bucketId)
-        .replaceAll('{fileId}', fileId);
+    final String apiPath = '/storage/buckets/$bucketId/files/$fileId/download';
 
     final Map<String, dynamic> params = {
       'token': token,
@@ -211,9 +197,7 @@ class Storage extends Service {
     enums.ImageFormat? output,
     String? token,
   }) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files/{fileId}/preview'
-        .replaceAll('{bucketId}', bucketId)
-        .replaceAll('{fileId}', fileId);
+    final String apiPath = '/storage/buckets/$bucketId/files/$fileId/preview';
 
     final Map<String, dynamic> params = {
       'width': width,
@@ -249,9 +233,7 @@ class Storage extends Service {
     required String fileId,
     String? token,
   }) async {
-    final String apiPath = '/storage/buckets/{bucketId}/files/{fileId}/view'
-        .replaceAll('{bucketId}', bucketId)
-        .replaceAll('{fileId}', fileId);
+    final String apiPath = '/storage/buckets/$bucketId/files/$fileId/view';
 
     final Map<String, dynamic> params = {
       'token': token,

--- a/lib/services/teams.dart
+++ b/lib/services/teams.dart
@@ -58,7 +58,7 @@ class Teams extends Service {
 
   /// Get a team by its ID. All team members have read access for this resource.
   Future<models.Team> get({required String teamId}) async {
-    final String apiPath = '/teams/{teamId}'.replaceAll('{teamId}', teamId);
+    final String apiPath = '/teams/$teamId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -79,7 +79,7 @@ class Teams extends Service {
     required String teamId,
     required String name,
   }) async {
-    final String apiPath = '/teams/{teamId}'.replaceAll('{teamId}', teamId);
+    final String apiPath = '/teams/$teamId';
 
     final Map<String, dynamic> apiParams = {'name': name};
 
@@ -98,7 +98,7 @@ class Teams extends Service {
   /// Delete a team using its ID. Only team members with the owner role can
   /// delete the team.
   Future delete({required String teamId}) async {
-    final String apiPath = '/teams/{teamId}'.replaceAll('{teamId}', teamId);
+    final String apiPath = '/teams/$teamId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -122,10 +122,7 @@ class Teams extends Service {
     List<String>? queries,
     String? search,
   }) async {
-    final String apiPath = '/teams/{teamId}/memberships'.replaceAll(
-      '{teamId}',
-      teamId,
-    );
+    final String apiPath = '/teams/$teamId/memberships';
 
     final Map<String, dynamic> apiParams = {
       'queries': queries,
@@ -174,10 +171,7 @@ class Teams extends Service {
     String? url,
     String? name,
   }) async {
-    final String apiPath = '/teams/{teamId}/memberships'.replaceAll(
-      '{teamId}',
-      teamId,
-    );
+    final String apiPath = '/teams/$teamId/memberships';
 
     final Map<String, dynamic> apiParams = {
       'email': email,
@@ -207,9 +201,7 @@ class Teams extends Service {
     required String teamId,
     required String membershipId,
   }) async {
-    final String apiPath = '/teams/{teamId}/memberships/{membershipId}'
-        .replaceAll('{teamId}', teamId)
-        .replaceAll('{membershipId}', membershipId);
+    final String apiPath = '/teams/$teamId/memberships/$membershipId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -234,9 +226,7 @@ class Teams extends Service {
     required String membershipId,
     required List<String> roles,
   }) async {
-    final String apiPath = '/teams/{teamId}/memberships/{membershipId}'
-        .replaceAll('{teamId}', teamId)
-        .replaceAll('{membershipId}', membershipId);
+    final String apiPath = '/teams/$teamId/memberships/$membershipId';
 
     final Map<String, dynamic> apiParams = {'roles': roles};
 
@@ -259,9 +249,7 @@ class Teams extends Service {
     required String teamId,
     required String membershipId,
   }) async {
-    final String apiPath = '/teams/{teamId}/memberships/{membershipId}'
-        .replaceAll('{teamId}', teamId)
-        .replaceAll('{membershipId}', membershipId);
+    final String apiPath = '/teams/$teamId/memberships/$membershipId';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -290,9 +278,7 @@ class Teams extends Service {
     required String userId,
     required String secret,
   }) async {
-    final String apiPath = '/teams/{teamId}/memberships/{membershipId}/status'
-        .replaceAll('{teamId}', teamId)
-        .replaceAll('{membershipId}', membershipId);
+    final String apiPath = '/teams/$teamId/memberships/$membershipId/status';
 
     final Map<String, dynamic> apiParams = {'userId': userId, 'secret': secret};
 
@@ -312,10 +298,7 @@ class Teams extends Service {
   /// need to be shared by all team members, prefer storing them in [user
   /// preferences](https://appwrite.io/docs/references/cloud/client-web/account#getPrefs).
   Future<models.Preferences> getPrefs({required String teamId}) async {
-    final String apiPath = '/teams/{teamId}/prefs'.replaceAll(
-      '{teamId}',
-      teamId,
-    );
+    final String apiPath = '/teams/$teamId/prefs';
 
     final Map<String, dynamic> apiParams = {};
 
@@ -338,10 +321,7 @@ class Teams extends Service {
     required String teamId,
     required Map prefs,
   }) async {
-    final String apiPath = '/teams/{teamId}/prefs'.replaceAll(
-      '{teamId}',
-      teamId,
-    );
+    final String apiPath = '/teams/$teamId/prefs';
 
     final Map<String, dynamic> apiParams = {'prefs': prefs};
 


### PR DESCRIPTION
…ods.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

in dart, almost every operation on a string creates a new object in memory, previously, the `apiPath` variable in service methods was first declared in it's generic form then specific parts were modified with proper values through the `replaceAll()` method called on the string, which is very inefficient and weird ! this pr removes this and instead the path is declared directly with the proper parts through a variable refrence

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)