### PR TITLE
Fix user mapping code for prefs

### DIFF
--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -99,7 +99,7 @@ class User implements Model {
       emailVerification: map['emailVerification'],
       phoneVerification: map['phoneVerification'],
       mfa: map['mfa'],
-      prefs: Preferences.fromMap(map['prefs']),
+      prefs: Preferences.fromMap(map['prefs']['data']),
       targets: List<Target>.from(map['targets'].map((p) => Target.fromMap(p))),
       accessedAt: map['accessedAt'].toString(),
     );

--- a/test/src/models/user_test.dart
+++ b/test/src/models/user_test.dart
@@ -18,7 +18,7 @@ void main() {
         emailVerification: true,
         phoneVerification: true,
         mfa: true,
-        prefs: Preferences(data: {}),
+        prefs: Preferences(data: {'language': 'en'}),
         targets: [],
         accessedAt: '2020-10-15T06:38:00.000+00:00',
       );
@@ -39,6 +39,7 @@ void main() {
       expect(result.emailVerification, true);
       expect(result.phoneVerification, true);
       expect(result.mfa, true);
+      expect(result.prefs.data, {'language': 'en'});
       expect(result.targets, []);
       expect(result.accessedAt, '2020-10-15T06:38:00.000+00:00');
     });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In `User` model, `fromMap()` and `toMap()` methods do not share exact opposite logic for `prefs` mapping. When you convert a `User` object to a `Map`, you would also expect to be able to re-convert that `Map` to `User` using `fromMap` method. It does not do that right now for the `prefs` field. This PR fixes that.

## Test Plan

Existing `user_test.dart` code is not testing User.prefs field properly. That's why `prefs` mapping in `User` is probably overlooked. I added a sample p`refs` data to test it properly.

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.