### PR TITLE
Fix/row frommap data column bug

### DIFF
--- a/lib/src/models/row.dart
+++ b/lib/src/models/row.dart
@@ -45,6 +45,7 @@ class Row implements Model {
       $createdAt: map['\$createdAt'].toString(),
       $updatedAt: map['\$updatedAt'].toString(),
       $permissions: List.from(map['\$permissions'] ?? []),
+      // Assign the entire map to data
       data: map,
     );
   }

--- a/test/src/models/row_test.dart
+++ b/test/src/models/row_test.dart
@@ -27,7 +27,8 @@ void main() {
       expect(result.$permissions, []);
     });
 
-    // Test for the specific bug reported in issue #281
+    // Test for the specific bug
+    //reported in issue #281
     test('fromMap should handle columns named data without type errors', () {
       final map = {
         '\$id': 'row123',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Row model's data field to store the complete input map instead of selectively extracting a nested key, improving data preservation.

* **Tests**
  * Added test coverage for Row model data field handling across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->