### PR TITLE
HS-823973: Defer ClientIO init() to prevent JNI crash on Android release mode

### DIFF
--- a/lib/src/client_io.dart
+++ b/lib/src/client_io.dart
@@ -68,7 +68,6 @@ class ClientIO extends ClientBase with ClientMixin {
       _endPoint.startsWith(RegExp("http://|https://")),
       "endPoint $_endPoint must start with 'http'",
     );
-    init();
   }
 
   @override

--- a/test/src/client_io_test.dart
+++ b/test/src/client_io_test.dart
@@ -1,0 +1,51 @@
+@TestOn('vm')
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:appwrite/src/client_io.dart';
+
+class FakePathProvider extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async => '/tmp/test_cookies';
+}
+
+void main() {
+  group('ClientIO', () {
+    setUp(() {
+      PathProviderPlatform.instance = FakePathProvider();
+    });
+
+    test('constructor should not eagerly call init()', () {
+      // Creating a ClientIO should NOT trigger init() immediately.
+      // If init() is called eagerly, it causes "No JNI instance is available"
+      // errors on Android in release mode because the platform channels
+      // are not yet ready when the constructor runs.
+      final client = ClientIO(
+        endPoint: 'https://cloud.appwrite.io/v1',
+        selfSigned: false,
+      );
+
+      // init() should not have been called yet - initialization should
+      // be deferred until the first API call
+      expect(client.initProgress, isFalse,
+          reason: 'init() should not be called eagerly in the constructor');
+      expect(client.initialized, isFalse,
+          reason: 'Client should not be initialized until first API call');
+    });
+
+    test('init() should be called lazily on first API call', () async {
+      final client = ClientIO(
+        endPoint: 'https://cloud.appwrite.io/v1',
+        selfSigned: false,
+      );
+
+      // Before any call, client should not be initialized
+      expect(client.initialized, isFalse);
+
+      // Trigger initialization by calling init() directly
+      await client.init();
+
+      // After init, client should be initialized
+      expect(client.initialized, isTrue);
+    });
+  });
+}

--- a/test/src/client_io_test.dart
+++ b/test/src/client_io_test.dart
@@ -1,17 +1,34 @@
 @TestOn('vm')
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:appwrite/src/client_io.dart';
 
 class FakePathProvider extends PathProviderPlatform {
+  late String _tempPath;
+
+  FakePathProvider() {
+    _tempPath = Directory.systemTemp.createTempSync('appwrite_test_').path;
+  }
+
   @override
-  Future<String?> getApplicationDocumentsPath() async => '/tmp/test_cookies';
+  Future<String?> getApplicationDocumentsPath() async => _tempPath;
 }
 
 void main() {
   group('ClientIO', () {
+    late FakePathProvider fakePathProvider;
+
     setUp(() {
-      PathProviderPlatform.instance = FakePathProvider();
+      fakePathProvider = FakePathProvider();
+      PathProviderPlatform.instance = fakePathProvider;
+    });
+
+    tearDown(() {
+      try {
+        Directory(fakePathProvider._tempPath).deleteSync(recursive: true);
+      } catch (_) {}
     });
 
     test('constructor should not eagerly call init()', () {


### PR DESCRIPTION
## Summary
- Remove eager `init()` call from `ClientIO` constructor that caused "No JNI instance is available" errors on Android in release mode
- The constructor was calling `init()` which triggers `getApplicationDocumentsDirectory()` before the Flutter engine/JNI bridge is fully ready
- The `call()` method already has lazy initialization logic (lines 508-513), so the eager call was unnecessary
- Added test to verify `init()` is not called during construction

## Test plan
- [ ] Verify existing tests pass (CI)
- [ ] Test Flutter app on Android in release mode — `Client()` constructor should no longer throw JNI errors
- [ ] Verify API calls still work correctly (lazy init triggers on first `call()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)