### PR TITLE
HS-1258249: fix uncatchable realtime 1008 error and endless 1-second reconnect loop

### DIFF
--- a/lib/src/realtime_mixin.dart
+++ b/lib/src/realtime_mixin.dart
@@ -39,6 +39,7 @@ mixin RealtimeMixin {
   bool _pendingSocketRebuild = false;
   int? get closeCode => _websok?.closeCode;
   bool _reconnect = true;
+  AppwriteException? _fatalError;
   int _retries = 0;
   StreamSubscription? _websocketSubscription;
   bool _creatingSocket = false;
@@ -99,7 +100,22 @@ mixin RealtimeMixin {
         _lastUrl = uri.toString();
         _websok = await getWebSocket(uri);
       }
-      _retries = 0;
+      // A freshly requested connection clears any recorded fatal state, so a
+      // caller that re-authenticates and subscribes again gets a working
+      // client back.
+      _reconnect = true;
+      _fatalError = null;
+      // onError and onDone both fire for a single failure on some platforms
+      // (the browser channel emits error-then-done), which would otherwise
+      // schedule two reconnects and double-count the retries.
+      var retryScheduled = false;
+      void scheduleRetry() {
+        if (retryScheduled) return;
+        retryScheduled = true;
+        _retry();
+      }
+
+      await _websocketSubscription?.cancel();
       _websocketSubscription = _websok?.stream.listen((response) {
         final data = RealtimeResponse.fromJson(response);
         switch (data.type) {
@@ -128,6 +144,11 @@ mixin RealtimeMixin {
                 'queries': entry.value.queries,
               };
             }
+            // Reset the backoff only once the application-level handshake
+            // succeeded. Resetting it as soon as the transport connects makes
+            // every attempt look like the first one, so a server that keeps
+            // rejecting the connection is retried once a second forever.
+            _retries = 0;
             _appConnected = true;
             _sendPendingSubscribes();
             _flushPendingPresence();
@@ -159,14 +180,14 @@ mixin RealtimeMixin {
       }, onDone: () {
         _appConnected = false;
         _stopHeartbeat();
-        _retry();
+        scheduleRetry();
       }, onError: (err, stack) {
         _appConnected = false;
         _stopHeartbeat();
         for (var subscription in _subscriptions.values) {
           subscription.controller.addError(err, stack);
         }
-        _retry();
+        scheduleRetry();
       });
     } catch (e) {
       if (e is AppwriteException) {
@@ -184,8 +205,14 @@ mixin RealtimeMixin {
   }
 
   void _retry() async {
-    if (!_reconnect || _websok?.closeCode == status.policyViolation) {
-      _reconnect = true;
+    // `closeCode` is an unreliable signal for a policy violation: it is null
+    // when the failure surfaces through the channel's onError path, and it is
+    // 1006/1000 when a proxy or tunnel tears the connection down without
+    // forwarding the server's 1008 close frame. `_fatalError` records the
+    // rejection itself, so it holds in all of those cases.
+    if (!_reconnect ||
+        _fatalError != null ||
+        _websok?.closeCode == status.policyViolation) {
       return;
     }
     _retries++;
@@ -382,9 +409,33 @@ mixin RealtimeMixin {
 
   void handleError(RealtimeResponse response) {
     if (response.data['code'] == status.policyViolation) {
-      throw AppwriteException(response.data["message"], response.data["code"]);
+      _handleFatalError(
+          AppwriteException(response.data["message"], response.data["code"]));
     } else {
       _retry();
+    }
+  }
+
+  /// A policy violation (1008) means the server rejected this connection at the
+  /// application level, so reconnecting only gets rejected the same way.
+  ///
+  /// Throwing from here would escape into the zone's uncaught error handler —
+  /// this runs inside the WebSocket stream listener — leaving the socket open,
+  /// the retry loop running and the exception unreachable for app code.
+  /// Instead the connection is torn down and the exception is delivered to
+  /// every subscriber, so callers can react (e.g. re-authenticate and
+  /// subscribe again).
+  void _handleFatalError(AppwriteException error) {
+    _fatalError = error;
+    _reconnect = false;
+    _appConnected = false;
+    _stopHeartbeat();
+    final subscription = _websocketSubscription;
+    _websocketSubscription = null;
+    subscription?.cancel();
+    _websok?.sink.close(status.policyViolation, error.message);
+    for (var subscription in _subscriptions.values) {
+      subscription.controller.addError(error);
     }
   }
 

--- a/lib/src/realtime_mixin.dart
+++ b/lib/src/realtime_mixin.dart
@@ -40,6 +40,7 @@ mixin RealtimeMixin {
   int? get closeCode => _websok?.closeCode;
   bool _reconnect = true;
   AppwriteException? _fatalError;
+  bool _retryScheduled = false;
   int _retries = 0;
   StreamSubscription? _websocketSubscription;
   bool _creatingSocket = false;
@@ -91,7 +92,13 @@ mixin RealtimeMixin {
         _websok = await getWebSocket(uri);
         _lastUrl = uri.toString();
       } else {
-        if (_lastUrl == uri.toString() && _websok?.closeCode == null) {
+        // A rejected socket is unusable even while its `closeCode` is still
+        // null, because the close it was sent has not completed yet. Reusing
+        // it here would push the pending subscribes into a dying connection
+        // and leave `_fatalError` set, so the client would never recover.
+        if (_lastUrl == uri.toString() &&
+            _websok?.closeCode == null &&
+            _fatalError == null) {
           _sendPendingSubscribes();
           _creatingSocket = false;
           return;
@@ -105,15 +112,7 @@ mixin RealtimeMixin {
       // client back.
       _reconnect = true;
       _fatalError = null;
-      // onError and onDone both fire for a single failure on some platforms
-      // (the browser channel emits error-then-done), which would otherwise
-      // schedule two reconnects and double-count the retries.
-      var retryScheduled = false;
-      void scheduleRetry() {
-        if (retryScheduled) return;
-        retryScheduled = true;
-        _retry();
-      }
+      _retryScheduled = false;
 
       await _websocketSubscription?.cancel();
       _websocketSubscription = _websok?.stream.listen((response) {
@@ -180,14 +179,14 @@ mixin RealtimeMixin {
       }, onDone: () {
         _appConnected = false;
         _stopHeartbeat();
-        scheduleRetry();
+        _scheduleRetry();
       }, onError: (err, stack) {
         _appConnected = false;
         _stopHeartbeat();
         for (var subscription in _subscriptions.values) {
           subscription.controller.addError(err, stack);
         }
-        scheduleRetry();
+        _scheduleRetry();
       });
     } catch (e) {
       if (e is AppwriteException) {
@@ -202,6 +201,17 @@ mixin RealtimeMixin {
         Future.microtask(_createSocket);
       }
     }
+  }
+
+  /// A single connection failure can surface more than once — the browser
+  /// channel emits error-then-done, and a server error frame is usually
+  /// followed by the stream terminating. Without this guard each of those
+  /// paths schedules its own reconnect and bumps `_retries`, so one failure
+  /// looks like several and rebuilds the socket twice.
+  void _scheduleRetry() {
+    if (_retryScheduled) return;
+    _retryScheduled = true;
+    _retry();
   }
 
   void _retry() async {
@@ -412,7 +422,7 @@ mixin RealtimeMixin {
       _handleFatalError(
           AppwriteException(response.data["message"], response.data["code"]));
     } else {
-      _retry();
+      _scheduleRetry();
     }
   }
 

--- a/test/src/realtime_mixin_test.dart
+++ b/test/src/realtime_mixin_test.dart
@@ -135,6 +135,13 @@ void main() {
       // scheduled — previously the client hammered the server once a second.
       await Future.delayed(Duration(milliseconds: 1500));
       expect(channels, hasLength(1));
+
+      // Once the application has reacted to the error (e.g. re-authenticated),
+      // subscribing again must open a fresh socket rather than reusing the
+      // rejected one, whose close has not completed yet.
+      realtime.subscribe(['tables']);
+      await Future.delayed(Duration(milliseconds: 50));
+      expect(channels, hasLength(2));
     });
 
     test('still reconnects after a recoverable error', () async {

--- a/test/src/realtime_mixin_test.dart
+++ b/test/src/realtime_mixin_test.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:appwrite/src/client.dart';
+import 'package:appwrite/src/exception.dart';
+import 'package:appwrite/src/realtime_mixin.dart';
+import 'package:appwrite/src/realtime_subscription.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class FakeClient implements Client {
+  @override
+  Map<String, String> config = {'project': 'testProject'};
+
+  @override
+  String? get endPointRealtime => 'wss://demo.appwrite.io/v1';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeWebSocketSink implements WebSocketSink {
+  final List<dynamic> sent = [];
+  bool closed = false;
+  int? closeCode;
+
+  @override
+  void add(dynamic data) => sent.add(data);
+
+  @override
+  Future close([int? closeCode, String? closeReason]) async {
+    closed = true;
+    this.closeCode = closeCode;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeWebSocketChannel implements WebSocketChannel {
+  final StreamController<dynamic> _controller =
+      StreamController<dynamic>.broadcast();
+
+  @override
+  final FakeWebSocketSink sink = FakeWebSocketSink();
+
+  int? _closeCode;
+
+  @override
+  Stream<dynamic> get stream => _controller.stream;
+
+  @override
+  int? get closeCode => _closeCode;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => Future.value();
+
+  /// Simulate a frame sent by the server.
+  void emit(Map<String, dynamic> message) =>
+      _controller.add(jsonEncode(message));
+
+  /// Simulate the connection dropping. [code] is null when the socket dies
+  /// without a close frame reaching the client (e.g. a proxy/tunnel timeout).
+  void dropConnection({int? code}) {
+    _closeCode = code;
+    _controller.close();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class TestRealtime with RealtimeMixin {
+  TestRealtime(Client client, WebSocketFactory factory) {
+    this.client = client;
+    getWebSocket = factory;
+  }
+
+  RealtimeSubscription subscribe(List<Object> channels) =>
+      subscribeTo(channels);
+}
+
+void main() {
+  group('RealtimeMixin policy violation (1008)', () {
+    late List<FakeWebSocketChannel> channels;
+    late TestRealtime realtime;
+
+    setUp(() {
+      channels = [];
+      realtime = TestRealtime(FakeClient(), (uri) async {
+        final channel = FakeWebSocketChannel();
+        channels.add(channel);
+        return channel;
+      });
+    });
+
+    test(
+        'delivers the exception to subscribers and stops reconnecting when the '
+        'server rejects the connection', () async {
+      final errors = <Object>[];
+      final subscription = realtime.subscribe(['tables']);
+      subscription.stream.listen((_) {}, onError: errors.add);
+
+      // Let the socket open and register its listener.
+      await Future.delayed(Duration(milliseconds: 50));
+      expect(channels, hasLength(1));
+
+      // The server rejects the connection at the application level, then the
+      // socket dies without the 1008 close code reaching the client — this is
+      // what happens behind a tunnel/proxy that drops the connection itself.
+      channels.first.emit({
+        'type': 'error',
+        'data': {'code': 1008, 'message': 'Server Error'},
+      });
+      await Future.delayed(Duration(milliseconds: 50));
+
+      // The exception must reach application code instead of being thrown as
+      // an uncatchable async error inside the WebSocket stream listener.
+      expect(errors, hasLength(1));
+      expect(errors.single, isA<AppwriteException>());
+      expect((errors.single as AppwriteException).code, 1008);
+
+      // The dead socket must be torn down.
+      expect(channels.first.sink.closed, isTrue);
+
+      channels.first.dropConnection();
+
+      // Retrying would be rejected the same way, so no reconnect must be
+      // scheduled — previously the client hammered the server once a second.
+      await Future.delayed(Duration(milliseconds: 1500));
+      expect(channels, hasLength(1));
+    });
+
+    test('still reconnects after a recoverable error', () async {
+      realtime.subscribe(['tables']);
+      await Future.delayed(Duration(milliseconds: 50));
+      expect(channels, hasLength(1));
+
+      channels.first.emit({
+        'type': 'error',
+        'data': {'code': 1011, 'message': 'Server Error'},
+      });
+      channels.first.dropConnection(code: 1011);
+
+      await Future.delayed(Duration(milliseconds: 1500));
+      expect(channels, hasLength(2));
+    }, timeout: Timeout(Duration(seconds: 30)));
+  });
+}


### PR DESCRIPTION
## Problem

Reported in HS-1258249: a self-hosted user behind a Cloudflare tunnel gets this on Flutter web after the socket has been idle for a couple of hours, repeating once per second forever:

```
Reconnecting in 1 seconds.
DartError: AppwriteException: , Error: Server Error (1008)
package:appwrite/src/realtime_mixin.dart 385:7   handleError
package:appwrite/src/realtime_mixin.dart 107:13
dart-sdk/lib/async/zone.dart 891:9               runUnaryGuarded
```

## Root cause

`handleError` treated a 1008 policy violation as fatal by `throw`ing — but it runs inside the `_websok.stream.listen` onData callback. A throw there is forwarded to the zone's uncaught-error handler, so it:

- never reaches the `try/catch` in `_createSocket` (which has already returned),
- never cancels the subscription or closes the socket,
- never reaches `subscription.stream.listen(onError:)`, so app code cannot catch it, prompt for re-auth, or stop the client.

The fatal signal was simply discarded. The only thing that then stopped the reconnect loop was the incidental `_websok?.closeCode == status.policyViolation` check in `_retry`, and that check is unreliable — `closeCode` is `null` when the failure surfaces through the channel's onError path, and `1006`/`1000` when a proxy or tunnel terminates the connection without forwarding the server's 1008 close frame. In all of those cases `_retry()` reconnected straight back into the same rejection.

On top of that, `_retries = 0` was reset immediately after the WebSocket object was created, *before* the application-level `connected` handshake. When the transport connects fine but the server rejects at the app level, the counter was wiped on every attempt, so `_getTimeout()` always returned 1 — matching the repeated `Reconnecting in 1 seconds.` in the report.

## Fix

- `handleError` no longer throws. It records the fatal state, stops the heartbeat, cancels the stream subscription, closes the socket, and delivers the `AppwriteException` to every subscriber's controller so applications can handle it.
- `_retry` is gated on that recorded state instead of the racy `closeCode` check, and no longer resets `_reconnect = true` on its early return (which made the old guard one-shot).
- `_retries` is reset in the `'connected'` case, after the handshake succeeds, so the backoff actually escalates on post-connect failures.
- `onError` and `onDone` no longer schedule two reconnects for a single failure (the browser channel emits error-then-done), and the stale `_websocketSubscription` is cancelled before being replaced.

A fresh `_createSocket()` — i.e. an explicit `subscribeTo` / `upsertPresence` after the app re-authenticates — clears the recorded fatal state, so the client is usable again.

## Tests

New `test/src/realtime_mixin_test.dart`:

- **Reproduces the report**: server sends the 1008 error frame and the socket then dies without the close code reaching the client (the tunnel case). Before the fix this failed with the exact `handleError` → `_createSocket.<fn>` stack trace from the ticket and no error delivered to the subscriber. Now the `AppwriteException` reaches `subscription.stream`, the socket is closed, and no reconnect is scheduled.
- **Regression guard**: a recoverable (non-1008) error still reconnects.

Full suite: 388 existing tests + 2 new ones pass. `flutter analyze` reports no new issues in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)