### PR TITLE
solve issue #256

### DIFF
--- a/lib/services/account.dart
+++ b/lib/services/account.dart
@@ -1033,8 +1033,15 @@ class Account extends Service {
     final String apiPath = '/account/sessions/oauth2/{provider}'
         .replaceAll('{provider}', provider.value);
 
+    // Do NOT forward the custom success URL to the server.
+    // The server only appends key/secret to the redirect when the success path
+    // matches its internal default (/auth/oauth2/success). Sending a custom URL
+    // causes the server to skip adding key/secret, so the Flutter webAuth
+    // callback never receives them → "Invalid OAuth2 Response" (500).
+    // Let the server use its default success path so key/secret are always
+    // added. The custom success URL is used only as the callbackUrlScheme so
+    // Flutter can intercept the redirect after key/secret have been appended.
     final Map<String, dynamic> params = {
-      if (success != null) 'success': success,
       if (failure != null) 'failure': failure,
       if (scopes != null) 'scopes': scopes,
       'project': client.config['project'],
@@ -1369,8 +1376,14 @@ class Account extends Service {
     final String apiPath = '/account/tokens/oauth2/{provider}'
         .replaceAll('{provider}', provider.value);
 
+    // Do NOT forward the custom success URL to the server.
+    // The server (account.php) only appends userId/secret to the redirect
+    // when the success path matches its internal default. Sending a custom
+    // URL causes the server to skip adding them → "Invalid OAuth2 Response"
+    // (500) or "Invalid success param" (400) if the URL is not registered.
+    // Let the server use its default path; use the custom success URL only
+    // as the callbackUrlScheme so Flutter can intercept the redirect.
     final Map<String, dynamic> params = {
-      if (success != null) 'success': success,
       if (failure != null) 'failure': failure,
       if (scopes != null) 'scopes': scopes,
       'project': client.config['project'],

--- a/lib/src/client_io.dart
+++ b/lib/src/client_io.dart
@@ -479,11 +479,25 @@ class ClientIO extends ClientBase with ClientMixin {
 
   @override
   Future webAuth(Uri url, {String? callbackUrlScheme}) {
+    // Derive the actual URI scheme to listen for.
+    // If the caller passed a full URL (e.g. "https://myapp.com/callback"),
+    // extract just the scheme ("https"). Otherwise use it as-is if it looks
+    // like a bare scheme, or fall back to the default appwrite-callback scheme.
+    String resolvedScheme = "appwrite-callback-${config['project']!}";
+    if (callbackUrlScheme != null && _customSchemeAllowed) {
+      final parsed = Uri.tryParse(callbackUrlScheme);
+      if (parsed != null && parsed.hasScheme && parsed.host.isNotEmpty) {
+        // full URL passed — use just the scheme portion
+        resolvedScheme = parsed.scheme;
+      } else {
+        // bare scheme passed (e.g. "myapp") — use as-is
+        resolvedScheme = callbackUrlScheme;
+      }
+    }
+
     return FlutterWebAuth2.authenticate(
       url: url.toString(),
-      callbackUrlScheme: callbackUrlScheme != null && _customSchemeAllowed
-          ? callbackUrlScheme
-          : "appwrite-callback-${config['project']!}",
+      callbackUrlScheme: resolvedScheme,
       options: const FlutterWebAuth2Options(
         useWebview: false,
       ),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->


## What does this PR do?

Fixes AppwriteException: Invalid OAuth2 Response. Key and Secret not available. (500), thrown by createOAuth2Session() and createOAuth2Token() whenever a custom (deep-link) success URL is passed in on mobile/desktop.

Root cause: the custom success URL was being forwarded to the server as a query param. The server compares its path against its own default success path to decide whether to append key/secret to the redirect. A custom deep-link scheme's path never matches that default, so the comparison silently fails and key/secret are omitted from the redirect — leaving the client with null for both and causing the crash. Web is unaffected since it completes login via a server-set session cookie instead of reading key/secret from the URL.

This PR:

Stops sending success to the server in both createOAuth2Session and createOAuth2Token (lib/services/account.dart). It's still used client-side only, to select the callback URL scheme webAuth() listens for. With success withheld, the server always falls back to its default path, so the key/secret check always passes.
Fixes webAuth() in lib/src/client_io.dart to extract just the scheme when callbackUrlScheme is a full URL rather than a bare scheme, instead of passing the whole URL through to flutter_web_auth_2 (which could never match it).

## Test Plan

Manually tested against a self-hosted Appwrite 1.7.4 instance:

 createOAuth2Session / createOAuth2Token with no custom success URL — unaffected, still works as before.
 createOAuth2Token with a custom deep-link success URL — previously threw the 500 error, now resolves with a valid userId/secret and completes the session.
 Flutter Web OAuth flow — unaffected, since it doesn't go through this code path.

No server-side (appwrite/appwrite) changes are required or included; this is a client-only fix.

## Related PRs and Issues

Fixes #256

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.